### PR TITLE
Rename Title from Software Center to Activities. Add space in suffix …

### DIFF
--- a/aslo/web/static/css/style.css
+++ b/aslo/web/static/css/style.css
@@ -92,3 +92,7 @@ footer a {
 .dropdown-menu  li {
     display: initial;
     }
+
+i.fa::before {
+    margin-right: 10px;
+}

--- a/aslo/web/templates/index.html
+++ b/aslo/web/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "partials/layout.html" %}
 
 {% block title %} 
-  {{ _('Software Center') }} 
+  {{ _('Activities') }} 
 {% endblock %} 
 
 {% block content %} 

--- a/aslo/web/templates/partials/layout.html
+++ b/aslo/web/templates/partials/layout.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link id="defaultIcon1" rel="shortcut icon" href="https://www.sugarlabs.org/assets/favicon_06.png" />
     <title>
-      {% block title %}{% endblock %} | {{ _('SugarLabs') }}
+      {% block title %}{% endblock %} | {{ _('Sugar Labs') }}
     </title>
  
     <link href="{{ url_for('web.static', filename='css/googleFonts.css') }}" rel="stylesheet" type="text/css" >


### PR DESCRIPTION
Rename Title from Software Center to Activities. Add space in suffix SugarLabs. Add space between font-awesome icons and words

[Many issues pertaining to aslo-v3 were discussed on Sugar-Devel Mailing list.](http://lists.sugarlabs.org/archive/sugar-devel/2018-September/055663.html)

This fixes space issue between font awesome icons and text and rename Software Center to aslo-v3.