### PR TITLE
Fixes broken frontend issues

### DIFF
--- a/aslo/web/static/css/style.css
+++ b/aslo/web/static/css/style.css
@@ -1,3 +1,6 @@
+.fa-card-space {
+    margin: 2%;
+}
 .temp-fix {       
     padding: 0px;
     margin-right: 100px;

--- a/aslo/web/templates/elements/activity_detail_card.html
+++ b/aslo/web/templates/elements/activity_detail_card.html
@@ -1,5 +1,5 @@
 <div class="card">
-  <h3 class="card-header pink lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-superpowers"></i>{{ _('Activity') }}</h3>
+  <h3 class="card-header pink lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-superpowers fa-card-space"></i>{{ _('Activity') }}</h3>
   <div class="card-content text-center">
     <h3 class="card-image-headline"> {{ activity.name.get(lang_code, activity.name.get('en', activity.name.get('en_US', _('No Translation') ))) }}</h3>
     <div class="card-image img-responsive">

--- a/aslo/web/templates/elements/developer_card.html
+++ b/aslo/web/templates/elements/developer_card.html
@@ -1,5 +1,5 @@
 <div class="card hidden-xs hidden-sm">
-  <h3 class="card-header info-color lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-users"></i>{{ _('Developers') }}</h3>
+  <h3 class="card-header info-color lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-users fa-card-space"></i>{{ _('Developers') }}</h3>
   <!-- Customized from here https://bootsnipp.com/snippets/featured/carousel-product-cart-slider -->
   <div class="card-body">
     <div class="row">

--- a/aslo/web/templates/elements/info_card.html
+++ b/aslo/web/templates/elements/info_card.html
@@ -1,5 +1,5 @@
 <div class="card">
-  <h3 class="card-header warning-color-dark lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-database"></i>{{ _('Details') }}</h3>
+  <h3 class="card-header warning-color-dark lighten-1 white-text text-center" style="padding: 15px;"><i class="fa fa-database fa-card-space"></i>{{ _('Details') }}</h3>
   <div class="card-body">
     <h4 style="padding: 20px;">
       {{ activity.summary.get(lang_code, activity.summary.get('en', activity.summary.get('en_US',_('No Translation')) )) }}

--- a/aslo/web/templates/elements/screenshot_carousel.html
+++ b/aslo/web/templates/elements/screenshot_carousel.html
@@ -1,5 +1,5 @@
 <div class="card hidden-xs hidden-sm">
-  <h3 class="card-header success-color white-text text-center" style="padding: 15px;"><i class="fa fa-picture-o"></i>{{ _('Screenshots') }}</h3>
+  <h3 class="card-header success-color white-text text-center" style="padding: 15px;"><i class="fa fa-picture-o fa-card-space"></i>{{ _('Screenshots') }}</h3>
   <div class="card-body">
     <div class="row">
       <div class="col-md-12">


### PR DESCRIPTION
In the detail view, the icons for the headings are too close to the text, e.g. "<spiky circle>Activity" and "<pancake stack>Details". Work out a way to increase the space between icons and headings. So that the front end looks better.

This fixes this issue, see screenshot: https://i.imgur.com/IRniEWD.png